### PR TITLE
Updated Splunk python SDK from 2.0.1 to 2.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ Lookup Watcher generates a log file is created in `$SPLUNK_HOME/var/log/splunk/`
 Feel free to open an issue on github or use the contact author on the SplunkBase link and I will try to get back to you when possible, thanks!
 
 ## Release Notes
+### 1.0.5
+Updated Splunk python SDK from 2.0.1 to 2.0.2 as per Splunk cloud compatibility requirements
+
 ### 1.0.4
 Updating python SDK to version 2.0.1
 

--- a/bin/lib/splunklib/__init__.py
+++ b/bin/lib/splunklib/__init__.py
@@ -30,5 +30,5 @@ def setup_logging(level, log_format=DEFAULT_LOG_FORMAT, date_format=DEFAULT_DATE
                         datefmt=date_format)
 
 
-__version_info__ = (2, 0, 1)
+__version_info__ = (2, 0, 2)
 __version__ = ".".join(map(str, __version_info__))

--- a/default/app.conf
+++ b/default/app.conf
@@ -12,7 +12,7 @@ label = TA-SplunkAdmins
 [launcher]
 author = Gareth Anderson
 description = TA app for Alerts for SplunkAdmins, this TA includes custom commands and modular inputs
-version = 1.0.4
+version = 1.0.5
 
 [package]
 id = TA-SplunkAdmins


### PR DESCRIPTION
Updated Splunk python SDK from 2.0.1 to 2.0.2 as per Splunk cloud compatibility requirements